### PR TITLE
memory leak fix

### DIFF
--- a/main.c
+++ b/main.c
@@ -52,8 +52,8 @@ int main(void)
 			if (strcmp(args[0], "exit") == 0)
 			{
 				/*We're quitting */
-				if (!buffer)
 				free(buffer);
+				free(path_copy);
 				exit(0);
 			}
 			if (strcmp(args[0], "copy") == 0)


### PR DESCRIPTION
Realized that path_copy still had memory allocation, this should run correctly now when a user passes an exit command.